### PR TITLE
Exclude .env.local file from version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,6 +129,8 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+#.env.localのファイルも除外する
+.env.local
 
 # Spyder project settings
 .spyderproject


### PR DESCRIPTION
.env.localのファイルをGithubにあげないように、gitgnoreに追加しました。